### PR TITLE
feat: add debug Docker image for troubleshooting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,15 @@ FROM base AS builder
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
+# Debug image with netshoot for troubleshooting
+# Includes bash, curl, wget, tcpdump, and many other debugging tools
+FROM nicolaka/netshoot:v0.15 AS debug
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/neonephos-katalis/opg-ewbi-operator:neonephos
+IMG_DEBUG ?= ghcr.io/neonephos-katalis/opg-ewbi-operator:neonephos-debug
 PLATFORM ?= linux/arm64
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
@@ -109,12 +110,23 @@ docker-build: docker-build-controller ## Build docker image for the manager
 docker-build-controller:
 	DOCKER_BUILDKIT=1 $(CONTAINER_TOOL) build --platform=${PLATFORM} -t ${IMG} --secret id=netrc,src=$(HOME)/.netrc .
 
+.PHONY: docker-build-debug
+docker-build-debug: docker-build-controller-debug ## Build docker image for the manager
+
+.PHONY: docker-build-controller-debug
+docker-build-controller-debug:
+	DOCKER_BUILDKIT=1 $(CONTAINER_TOOL) build --target debug --platform=${PLATFORM} -t ${IMG_DEBUG} --secret id=netrc,src=$(HOME)/.netrc .
+
 .PHONY: docker-push
 docker-push: docker-push-controller
 
 .PHONY: docker-push-controller
 docker-push-controller: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
+
+.PHONY: docker-push-debug
+docker-push-debug:
+	$(CONTAINER_TOOL) push ${IMG_DEBUG}
 
 .PHONY: docker-itest
 docker-itest: ## Run itests

--- a/README.md
+++ b/README.md
@@ -70,24 +70,32 @@ Install operator in host namespace, set API nodeport and set CRD to true to also
     chmod 600 ~/.netrc
     ```
 2. ```git clone https://github.com/neonephos-katalis/opg-ewbi-operator```
-4. After the download, open this folder via terminal and exec the following command:
+3. After the download, open this folder via terminal and exec the following command:
   ```make docker-build-controller```
       **or**
   ```docker build . --no-cache -t ghcr.io/neonephos-katalis/opg-ewbi-operator:neonephos --secret id=netrc,src=$HOME/.netrc .```
-5. ```bash git clone https://github.com/neonephos-katalis/opg-ewbi-api```
-6. After the download, open the created folder, `opg-ewbi-api`, via terminale and exec the following command:
+
+  **For debugging purposes**, you can build a debug image with bash and troubleshooting tools (curl, wget, tcpdump, dig, etc.):
+  ```make docker-build-debug```
+      **or**
+  ```docker build --target debug --no-cache -t ghcr.io/neonephos-katalis/opg-ewbi-operator:neonephos-debug --secret id=netrc,src=$HOME/.netrc .```
+
+  To use the debug image, install the chart with `--set image.tag=neonephos-debug` and exec into the pod with `kubectl exec -it <pod-name> -- bash`
+
+4. ```bash git clone https://github.com/neonephos-katalis/opg-ewbi-api```
+5. After the download, open the created folder, `opg-ewbi-api`, via terminale and exec the following command:
   ```docker-compose build federation --no-cache ```
    **or**
   ```docker compose build federation --no-cache ```
-7. ```docker login ghcr.io```
-8. In your cluster create a new namesapce (e.g. ```kubectl create ns federation```) after this exec this command. (replace $username and $accessToken with your username and accessToken used for the docker login ghcr.io command)
+6. ```docker login ghcr.io```
+7. In your cluster create a new namesapce (e.g. ```kubectl create ns federation```) after this exec this command. (replace $username and $accessToken with your username and accessToken used for the docker login ghcr.io command)
   ```bash
       kubectl -n federation create secret docker-registry opg-registry-secret \
       --docker-server=ghcr.io \
       --docker-username= $username \
       --docker-password= $accessToken
   ```
-9. In the end exec this command (in **OPG-EWBI-OPERATOR folder** via terminal)
+8. In the end exec this command (in **OPG-EWBI-OPERATOR folder** via terminal)
   ```bash
   helm install federation-manager dist/chart -n federation \
   --set federation.services.federation.nodePort=30080 \
@@ -111,7 +119,7 @@ docker push ghcr.io/neonephos-katalis/opg-ewbi-api-amd:neonephos
 ```
 
 The Nearby code is written to work in both role (HOST and GUEST).
-If you want test in local, you need two helm installation one for the host and one for the guest, use the following configuration of the helm command, but don't forget to follow the step 5-6 in both namespace (federation-host and federation-guest)
+If you want test in local, you need two helm installation one for the host and one for the guest, use the following configuration of the helm command, but don't forget to follow the step 8 for both namespaces (federation-host and federation-guest)
 
 ```bash
 helm install federationhost dist/chart -n federation-host \


### PR DESCRIPTION
This PR adds a debug variant of the operator Docker image that includes comprehensive troubleshooting tools while maintaining the same manager binary as the production image.
## Changes
- `Dockerfile`: Added new `debug` build stage using `nicolaka/netshoot:v0.15` base image
- `Makefile`: Added `docker-build-controller-debug` and `docker-push-controller-debug` targets and `IMG_DEBUG` variable
- `README.md`: Added documentation for building and deploying the debug image

## How was it tested?
- Built the image locally with  `make docker-build-debug` . Completed without errors.
- Deployed the image to a Kubernetes cluster and exec’d into the container to confirm the debugging tools are available.

@DavideLavermicoccaIPCEI @ignaziodinataliTIM @francescofiorentinoTIM  @seralogar @afernandeztelefonica @gunjald @rquerio, @varanto, @LC-TIM, @ChrisWeissDT, @maradwan, @wjost, @gainsley
