### PR TITLE
Fix watcher removal (issue #61)

### DIFF
--- a/internal/k8s/application_k8s.go
+++ b/internal/k8s/application_k8s.go
@@ -150,6 +150,6 @@ func (r *ApplicationReconciler) DeleteApplication(ctx context.Context, a *v1beta
 		return err
 	}
 	log.Info(">>> [App][K8s] Stopping background watcher for remote host")
-	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationHostIdLabel], a.Name)
+	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationNamespaceLabel], a.Name)
 	return nil
 }

--- a/internal/k8s/applicationinstance_k8s.go
+++ b/internal/k8s/applicationinstance_k8s.go
@@ -172,6 +172,6 @@ func (r *ApplicationInstanceReconciler) DeleteApplicationInstance(ctx context.Co
 		return err
 	}
 	log.Info(">>> [AppInst][K8s] Stopping background watcher for remote host")
-	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationHostIdLabel], a.Name)
+	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationNamespaceLabel], a.Name)
 	return nil
 }

--- a/internal/k8s/artefact_k8s.go
+++ b/internal/k8s/artefact_k8s.go
@@ -151,6 +151,6 @@ func (r *ArtefactReconciler) DeleteArtefact(ctx context.Context, a *v1beta1.Arte
 		return err
 	}
 	log.Info(">>> [Artefact][K8s] Stopping background watcher for remote host")
-	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationHostIdLabel], a.Name)
+	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationNamespaceLabel], a.Name)
 	return nil
 }

--- a/internal/k8s/federation_k8s.go
+++ b/internal/k8s/federation_k8s.go
@@ -228,6 +228,6 @@ func (r *FederationReconciler) DeleteFederation(ctx context.Context, f *v1beta1.
 		return err
 	}
 	log.Info(">>> [Federation][K8s] Stopping background watcher for remote host")
-	StopRemoteResourceWatcher(f.Labels[v1beta1.FederationHostIdLabel], f.Name)
+	StopRemoteResourceWatcher(f.Labels[v1beta1.FederationNamespaceLabel], f.Name)
 	return nil
 }

--- a/internal/k8s/file_k8s.go
+++ b/internal/k8s/file_k8s.go
@@ -161,6 +161,6 @@ func (r *FileReconciler) DeleteFile(ctx context.Context, f *v1beta1.File, feder 
 		return err
 	}
 	log.Info(">>> [File][K8s] Stopping background watcher for remote host")
-	StopRemoteResourceWatcher(f.Labels[v1beta1.FederationHostIdLabel], f.Name)
+	StopRemoteResourceWatcher(feder.Labels[v1beta1.FederationNamespaceLabel], f.Name)
 	return nil
 }

--- a/internal/k8s/watcher_k8s.go
+++ b/internal/k8s/watcher_k8s.go
@@ -41,7 +41,10 @@ var ApplicationInstanceRemoteEvents = make(chan event.GenericEvent)
 func StartRemoteResourceWatcher(ctx context.Context, hostClient dynamic.Interface, namespace, localResourceName, localResourceNS string, group, version, resource string) {
 	watchKey := fmt.Sprintf("%s/%s", namespace, localResourceName)
 
-	if _, loaded := activeResourceWatchers.LoadOrStore(watchKey, true); loaded {
+	watcherCtx, cancel := context.WithCancel(ctx)
+	if _, loaded := activeResourceWatchers.LoadOrStore(watchKey, cancel); loaded {
+		// Someone is already watching this key; discard the context we just made.
+		cancel()
 		return
 	}
 
@@ -106,7 +109,7 @@ func StartRemoteResourceWatcher(ctx context.Context, hostClient dynamic.Interfac
 	})
 
 	// Avviamo l'informer in background
-	go informer.Run(ctx.Done())
+	go informer.Run(watcherCtx.Done())
 }
 
 func StopRemoteResourceWatcher(namespace, localResourceName string) {


### PR DESCRIPTION
## What

Fix K8s-transport background watchers that never get cleaned up when a federated resource is deleted.

## Why

Every K8s-mode resource (Federation, File, Artefact, Application, ApplicationInstance) starts a background listener on the host cluster to receive status updates. On delete, that listener is supposed to shut down. We realised it never did, because the lookup key computed when starting a watcher didn't match the one computed when stopping it.

Confirmed on our test clusters: every delete leaked one goroutine + one open watch connection to the host apiserver, permanently, until the operator pod restarted.

Fixes #61 

## How

`internal/k8s/watcher_k8s.go`: `StartRemoteResourceWatcher` now creates a cancellable context and stores the resulting `context.CancelFunc` in the watcher registry, instead of a  `true` placeholder. The informer now runs against that context instead of the short-lived per-reconcile context it was accidentally wired to before. 

Tthe delete path was passing the host Federation name (`FederationHostIdLabel`) as the registry key, while the create path used the host's actual namespace `FederationNamespaceLabel`. 

We make every delete call to use `FederationNamespaceLabel`. 

## Testing

<!-- How was this verified? (unit tests, integration tests, manual testing, etc.) -->

- [ ] Unit tests added/updated
- [ X] Manual testing performed
- [ ] No testing needed (explain why)

Verified on two k8s clusters, each one runing the operator. For `File` and `Application`: create confirmed a real watcher registers; delete → confirmed a clean stop with a matching key in the logs; immediately recreate the same name,  confirmed a  new watcher registers. Confirmed host, guest status propagation still works end-to-end throughout.

## Breaking Changes

<!-- List any breaking changes, or write "None" -->

None

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Each commit is a single logical change
- [X] Code compiles
- [ ] Tests pass (not passing, but not due to any error introduced by this PR).
- [ ] CRD manifests regenerated if API types changed
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines